### PR TITLE
fix: 修复满级账号的信息展示问题

### DIFF
--- a/main/bilibili_live_stream_code.py
+++ b/main/bilibili_live_stream_code.py
@@ -228,7 +228,12 @@ class BiliLiveGUI:
         # 更新成长值信息
         growth = info_json["data"]["level_info"]["current_exp"]
         next_level = int(current_level) + 1
-        need_growth = info_json["data"]["level_info"]["next_exp"] - growth
+        next_exp = info_json["data"]["level_info"]["next_exp"]
+        if next_exp == '--':
+            need_growth = 0
+            next_level = int(current_level)
+        else:
+            need_growth = int(next_exp) - growth
         self.growth_var.set(growth)
         self.next_level_var.set(f"Lv.{next_level}")
         self.need_growth_var.set(need_growth)


### PR DESCRIPTION
满级账号的等级信息如下:
```
'level_info': {'current_level': 6, 'current_min': 28800, 'current_exp': 47679, 'next_exp': '--'}, 
```

现在的解析会抛异常, 需要兼容一下

```
    need_growth = info_json["data"]["level_info"]["next_exp"] - growth
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
TypeError: unsupported operand type(s) for -: 'str' and 'int'
```