### PR TITLE
fix: 修复macOS上创建托盘图标导致的崩溃

### DIFF
--- a/main/bilibili_live_stream_code.py
+++ b/main/bilibili_live_stream_code.py
@@ -577,10 +577,14 @@ class BiliLiveGUI:
                 self.on_close()
                 return
 
-
-        # 在新线程中运行托盘图标
-        self.tray_thread = threading.Thread(target=self.tray_icon.run, daemon=True)
-        self.tray_thread.start()
+        # 在新线程中运行托盘图标(Windows)
+        if sys.platform == "win32":
+            self.tray_thread = threading.Thread(
+                target=self.tray_icon.run, daemon=True)
+            self.tray_thread.start()
+        # 使用主线程创建图标，后台负责图标运行(macOS)
+        elif sys.platform == "darwin":
+            self.tray_icon.run_detached()
 
     def get_close_method(self):
         """获取关闭窗口的方法"""


### PR DESCRIPTION
修复了#26 的问题。

经lldb调试，发现macOS不允许在主线程之外进行UI相关操作

```
$ lldb -- python3 bilibili_live_stream_code.py
...
(lldb) c
Process 25956 resuming
2025-09-23 21:19:09.224519+0800 Python[25956:1694516] [User Defaults] CFPrefsPlistSource<0x7fd3a4080> (Domain: kCFPreferencesAnyApplication, User: kCFPreferencesCurrentUser, ByHost: No, Container: (null), Contents Need Refresh: No): Value for key NSRequiresAquaSystemAppearance was 1. Expected 0 ((null))
2025-09-23 21:19:12.832738+0800 Python[25956:1694527] [Common] Unable to obtain a task name port right for pid 607: (os/kern) failure (0x5)
2025-09-23 21:19:12.907791+0800 Python[25956:1694558] [StatusBar] Setting NSStatusItem property on background thread. This is unsupported and may crash your application. NSStatusItem properties should only be read/written on the main thread. Set a breakpoint on `updateStatusItemOnBackgroundThread:` to debug.
Process 25956 stopped
* thread #9, stop reason = EXC_BREAKPOINT (code=1, subcode=0x18e9d4800)
    frame #0: 0x000000018e9d4800 AppKit`NSUpdateCycleInitialize + 888
AppKit`NSUpdateCycleInitialize:
->  0x18e9d4800 <+888>: brk    #0x1
    0x18e9d4804 <+892>: bl     0x18f360884    ; symbol stub for: __stack_chk_fail
    0x18e9d4808 <+896>: adrp   x0, 2774
    0x18e9d480c <+900>: add    x0, x0, #0xf35 ; "NSUpdateCycle was already initialized."
Target 0: (Python) stopped.
```

> 2025-09-23 21:19:12.907791+0800 Python[25956:1694558] [StatusBar] Setting NSStatusItem property on background thread. This is unsupported and may crash your application. NSStatusItem properties should only be read/written on the main thread. Set a breakpoint on `updateStatusItemOnBackgroundThread:` to debug.

在macOS上，使用主线程创建托盘图标，实测托盘图标正常运行：
（抱歉之前和Dock搞混了）

<img width="118" height="154" alt="截屏2025-09-23 21 46 12" src="https://github.com/user-attachments/assets/523166ef-4395-4d67-bdca-10858bb54e5d" />
