### PR TITLE
Bugfix tifisht

### DIFF
--- a/main/GetCookies.py
+++ b/main/GetCookies.py
@@ -27,6 +27,7 @@ import json
 import tkinter
 import tkinter as tk
 from util import center_window
+from PIL import Image, ImageTk
 
 def get_qrcode() -> dict:
     """
@@ -62,14 +63,29 @@ def get_qr() -> tuple:
     qrcode_url = data["url"]
     qrcode_key = data["qrcode_key"]
 
-    # 显示二维码URL并生成文本二维码
-    output = io.StringIO()
-    qr = qrcode.QRCode()
-    qr.add_data(qrcode_url)
-    qr.print_ascii(out=output, tty=False, invert=False)
-    qr_string = output.getvalue()
 
-    return qr_string, qrcode_key
+            
+    qr = qrcode.QRCode(
+            version=None,  # 自动选择合适版本
+            error_correction=qrcode.constants.ERROR_CORRECT_H,  # 高纠错率
+            box_size=5,
+            border=4,
+        )
+    # 添加数据
+    qr.add_data(qrcode_url)
+    qr.make(fit=True)
+    qr_img = qr.make_image(fill_color="black", back_color="white")
+
+    scaled_img = qr_img.resize((400, 400), Image.Resampling.NEAREST)
+    photo = ImageTk.PhotoImage(scaled_img)
+
+    # # 显示二维码URL并生成文本二维码
+    # output = io.StringIO()
+    # qr = qrcode.QRCode()
+    # qr.add_data(qrcode_url)
+    # qr.print_ascii(out=output, tty=False, invert=False)
+    # qr_string = output.getvalue()
+    return photo, qrcode_key
 
 
 def login(qr_string: str, qrcode_key: str) -> dict:
@@ -168,7 +184,7 @@ def login_ui() -> dict | None:
     扫码登录窗口
     :return: 登录失败返回None，否则返回cookies
     """
-    window = tk.Tk()
+    window = tk.Toplevel()
     center_window(window, 600, 550)
     # 设置统一宽度的字体
     import platform
@@ -178,18 +194,22 @@ def login_ui() -> dict | None:
     else:
         label_font = ('Courier New', 12)
     window.title('B站推流码获取工具')
-    qr_str, qr_key = get_qr()
+    qr_img, qr_key = get_qr()
+
+
+
     cookies_list = [None]
     login_label = tk.Label(window, text='\n扫描二维码登录 ', anchor='center', font=label_font)
     login_label.pack()
-    tk.Label(window, text=qr_str, anchor='center', font=label_font).pack()
+
+    tk.Label(window, image=qr_img, anchor='center').pack()
     login_enter(window, qr_key, cookies_list, login_label, False)
 
     # 使窗口避免被遮挡，并且获取焦点
     window.attributes('-topmost', True)
     window.bind("<FocusIn>", lambda event: window.attributes('-topmost', False))
+    window.wait_window(window)
 
-    window.mainloop()
     return cookies_list[0]
 
 

--- a/main/bilibili_live_stream_code.py
+++ b/main/bilibili_live_stream_code.py
@@ -675,7 +675,8 @@ class BiliLiveGUI:
         """自动获取cookies"""
         self.log_message("开始自动获取账号信息...")
         # 在新线程中执行获取cookies的操作
-        threading.Thread(target=self._auto_get_cookies_thread, daemon=True).start()
+        # threading.Thread(target=self._auto_get_cookies_thread, daemon=True).start()
+        self._auto_get_cookies_thread()
 
     def _auto_get_cookies_thread(self):
         try:


### PR DESCRIPTION
### [bugfix]自动登录图片二维码
使用图片作为登录时的二维码，避免了因为不同字体导致的二维码变形问题，具体效果如下：<img width="1772" height="1335" alt="Snipaste_2026-01-06_06-31-09" src="https://github.com/user-attachments/assets/42a28416-479c-49ba-a285-4fa4fea7ba67" />
在linux以及windows环境下均可使用