### PR TITLE
将git clone的链接指定为...ChaceQC的仓库

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 1. **克隆仓库**
 
    ```bash
-   git clone https://github.com/your-repo/bilibili_live_stream_code.git
+   git clone https://github.com/ChaceQC/bilibili_live_stream_code.git
    cd bilibili_live_stream_code
    ```
 


### PR DESCRIPTION
clone的时候报错，将git clone链接指定为佬的仓库了