### PR TITLE
Fix: 修复不同Linux发行版的界面中文显示乱码问题

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1373,7 +1373,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -1433,7 +1432,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.27.tgz",
       "integrity": "sha512-aJ/UtoEyFySPBGarREmN4z6qNKpbEguYHMmXSiOGk69czc+zhs0NF6tEFrY8TZKAl8N/LYAkd4JHVd5E/AsSmw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.27",
         "@vue/compiler-sfc": "3.5.27",

--- a/frontend/src/components/ConsolePanel.vue
+++ b/frontend/src/components/ConsolePanel.vue
@@ -136,7 +136,7 @@ input:checked + .slider:before {
   padding: 15px; border-radius: 12px;
   flex: 1; /* Fill remaining space */
   overflow-y: auto;
-  font-family: monospace; font-size: 12px;
+  font-family: "Sarasa Mono SC", "Source Han Mono SC", "Noto Sans Mono CJK SC", "WenQuanYi Micro Hei Mono", monospace; font-size: 12px;
   box-shadow: inset 0 2px 8px rgba(0,0,0,0.2);
   min-height: 0;
 }

--- a/frontend/src/components/DanmuPanel.vue
+++ b/frontend/src/components/DanmuPanel.vue
@@ -165,7 +165,7 @@ onUnmounted(() => {
   background: #f2f2f2; /* QQ 经典的浅灰底色 */
   border-radius: 16px; /* 圆润边框 */
   overflow: hidden;
-  font-family: "Microsoft YaHei", sans-serif;
+  font-family: "PingFang SC", "Microsoft YaHei", "WenQuanYi Micro Hei", sans-serif;
   box-shadow: 0 4px 12px rgba(0,0,0,0.03);
 }
 

--- a/frontend/src/components/RtmpPanel.vue
+++ b/frontend/src/components/RtmpPanel.vue
@@ -154,7 +154,7 @@ const currentData = computed(() => {
   color: #555;
   border: 1px solid #d0d7de;
   cursor: text;
-  font-family: monospace;
+  font-family: "Sarasa Mono SC", "Source Han Mono SC", "Noto Sans Mono CJK SC", "WenQuanYi Micro Hei Mono", monospace;
   flex: 1;
   font-size: 12px;
   padding-right: 32px; /* 为图标留出空间 */

--- a/frontend/src/components/StreamPanel.vue
+++ b/frontend/src/components/StreamPanel.vue
@@ -228,6 +228,7 @@ const subPartitions = computed(() => {
 }
 
 .select-box {
+  font-family: "PingFang SC", "Microsoft YaHei", "WenQuanYi Micro Hei", sans-serif;
   cursor: pointer;
   appearance: none;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23444746' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -10,7 +10,7 @@
 
 body {
   margin: 0;
-  font-family: 'Inter', system-ui, sans-serif;
+  font-family: "PingFang SC", "Microsoft YaHei", "WenQuanYi Micro Hei", sans-serif !important;
   background: var(--bg-color);
   color: var(--text-main);
   overflow: hidden;
@@ -18,6 +18,7 @@ body {
 }
 
 .gemini-input {
+  font-family: "PingFang SC", "Microsoft YaHei", "WenQuanYi Micro Hei", sans-serif;
   background: var(--surface-color);
   border: 1px solid transparent;
   border-radius: 8px;
@@ -35,6 +36,7 @@ body {
 }
 
 .btn {
+  font-family: "PingFang SC", "Microsoft YaHei", "WenQuanYi Micro Hei", sans-serif;
   border: none;
   cursor: pointer;
   padding: 10px 20px;


### PR DESCRIPTION
### 问题描述
我使用的发行版是 Fedora 43。我下载了 Release 中的二进制包并执行，发现界面中许多中文显示都出现了乱码（方块）：

<img width="2560" height="1440" alt="Screenshot from 2026-02-17 18-43-26" src="https://github.com/user-attachments/assets/b34fc479-df86-46ec-b67b-a674ad1ffdeb" />

### 原因分析 & 解决方案
检查 CSS 文件后发现，部分样式没有指定 fallback 字体，或者只指定了 Windows 字体。导致 Linux 系统无法正确渲染中文。

我修改了 frontend/assets/css/style.css（或其他相关文件），添加了通用的字体族支持（如 PingFang SC、 WenQuanYi Micro Hei 等）。

### 验证结果
经过修改并重新编译运行，中文在 Fedora 下已成功显示：

<img width="1317" height="1013" alt="image" src="https://github.com/user-attachments/assets/1e9dee28-f5e3-4e26-9e1f-7a30479fc9c1" />

### 额外建议 (关于打包)
我在 Fedora 上执行作者打包的二进制包时发现，当前的 PyInstaller 配置可能会漏掉 _cffi_backend 模块，导致控制台出现报错：
[pywebview] GTK cannot be loaded
Traceback (most recent call last):
  File "webview/guilib.py", line 39, in import_gtk
  File "pyimod02_importers.py", line 457, in exec_module
  File "webview/platforms/gtk.py", line 28, in <module>
ModuleNotFoundError: No module named 'gi'
2026-02-17 18:39:40,768 - pywebview       - ERROR    - GTK cannot be loaded
Traceback (most recent call last):
  File "webview/guilib.py", line 39, in import_gtk
  File "pyimod02_importers.py", line 457, in exec_module
  File "webview/platforms/gtk.py", line 28, in <module>
ModuleNotFoundError: No module named 'gi'