### PR TITLE
Feat: 添加小窗口模式，弹幕框支持半透明和总在最前

### DIFF
--- a/backend/api_service.py
+++ b/backend/api_service.py
@@ -90,6 +90,8 @@ class ApiService:
         return self.window_service.window_close(lambda: self.config_manager.save())
     def get_window_position(self): return self.window_service.get_window_position()
     def window_drag(self, target_x, target_y): return self.window_service.window_drag(target_x, target_y)
+    def set_window_opacity(self, opacity_percent): return self.window_service.set_window_opacity(opacity_percent)
+    def set_window_topmost(self, on_top): return self.window_service.set_window_topmost(on_top)
 
     # --- User Proxy Methods ---
     def load_saved_config(self): return self.user_service.load_saved_config()

--- a/backend/services/window_service.py
+++ b/backend/services/window_service.py
@@ -1,3 +1,4 @@
+import sys
 import webview
 import logging
 
@@ -5,8 +6,11 @@ logger = logging.getLogger("WindowService")
 
 class WindowService:
     def __init__(self):
-        # [Fix] 移除 self.window 引用，避免 pywebview 遍历 ApiService -> WindowService -> window 导致递归错误
-        pass
+        self._hwnd = None  # 由 main.py 在窗口创建后注入（仅 Windows）
+
+    def set_hwnd(self, hwnd):
+        """由 main.py 注入主窗口 HWND"""
+        self._hwnd = hwnd
 
     def _get_window(self):
         if len(webview.windows) > 0:
@@ -62,3 +66,94 @@ class WindowService:
             except Exception:
                 # 忽略窗口关闭期间无法执行 JS 的错误 (如 ObjectDisposedException)
                 pass
+
+    # --- 透明度 & 置顶（仅 Windows，通过 WinAPI 实现）---
+
+    def _get_hwnd(self):
+        """获取主窗口 HWND。优先使用 main.py 注入值，否则枚举当前进程的顶级可见窗口。"""
+        if self._hwnd:
+            return self._hwnd
+
+        import ctypes
+        import os
+        from ctypes import wintypes
+
+        current_pid = os.getpid()
+        found = []
+
+        EnumWindowsProc = ctypes.WINFUNCTYPE(ctypes.c_bool, wintypes.HWND, wintypes.LPARAM)
+        user32 = ctypes.windll.user32
+
+        def enum_cb(hwnd, _):
+            if not user32.IsWindowVisible(hwnd):
+                return True
+            pid = wintypes.DWORD()
+            user32.GetWindowThreadProcessId(hwnd, ctypes.byref(pid))
+            if pid.value == current_pid:
+                found.append(hwnd)
+            return True
+
+        user32.EnumWindows(EnumWindowsProc(enum_cb), 0)
+
+        if found:
+            # 取第一个可见顶级窗口
+            hwnd = found[0]
+            logger.info(f"_get_hwnd: found via EnumWindows hwnd={hwnd:#x}")
+            self._hwnd = hwnd
+            return hwnd
+
+        logger.warning("_get_hwnd: no HWND found")
+        return None
+
+    def set_window_opacity(self, opacity_percent):
+        """设置窗口整体不透明度，opacity_percent: 0~100"""
+        if sys.platform != 'win32':
+            return {"code": -1, "msg": "仅支持 Windows"}
+
+        import ctypes
+        hwnd = self._get_hwnd()
+        if not hwnd:
+            return {"code": -1, "msg": "HWND 未找到，请重启应用"}
+
+        GWL_EXSTYLE   = -20
+        WS_EX_LAYERED = 0x00080000
+        LWA_ALPHA     = 0x00000002
+
+        # 限制最低 20，避免窗口完全消失
+        alpha = max(51, min(255, int(opacity_percent * 255 / 100)))
+
+        user32 = ctypes.windll.user32
+        # 用 PtrW 版本，64 位安全
+        user32.GetWindowLongPtrW.restype = ctypes.c_longlong
+        user32.SetWindowLongPtrW.restype = ctypes.c_longlong
+        ex_style = user32.GetWindowLongPtrW(hwnd, GWL_EXSTYLE)
+        user32.SetWindowLongPtrW(hwnd, GWL_EXSTYLE, ex_style | WS_EX_LAYERED)
+
+        user32.SetLayeredWindowAttributes.restype = ctypes.c_bool
+        result = user32.SetLayeredWindowAttributes(hwnd, 0, alpha, LWA_ALPHA)
+        logger.info(f"set_window_opacity: {opacity_percent}%  alpha={alpha}  ok={result}")
+        if not result:
+            err = ctypes.GetLastError()
+            return {"code": -1, "msg": f"SetLayeredWindowAttributes 失败，LastError={err}"}
+        return {"code": 0}
+
+    def set_window_topmost(self, on_top):
+        """设置窗口是否置顶"""
+        if sys.platform != 'win32':
+            return {"code": -1, "msg": "仅支持 Windows"}
+
+        import ctypes
+        hwnd = self._get_hwnd()
+        if not hwnd:
+            return {"code": -1, "msg": "HWND 未找到，请重启应用"}
+
+        # 必须用 c_void_p 包装，否则 64 位下 -1/-2 会被截断为无效地址
+        HWND_TOPMOST   = ctypes.c_void_p(-1)
+        HWND_NOTOPMOST = ctypes.c_void_p(-2)
+        SWP_NOMOVE = 0x0002
+        SWP_NOSIZE = 0x0001
+
+        insert_after = HWND_TOPMOST if on_top else HWND_NOTOPMOST
+        ctypes.windll.user32.SetWindowPos(hwnd, insert_after, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE)
+        logger.info(f"set_window_topmost: on_top={on_top}")
+        return {"code": 0}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, reactive, onMounted, onUnmounted, provide } from 'vue';
+import { ref, reactive, computed, onMounted, onUnmounted, provide } from 'vue';
 import QRCode from 'qrcode';
 import { useBridge } from '@/api/bridge';
 import Sidebar from '@/components/Sidebar.vue';
@@ -15,6 +15,12 @@ import WindowControls from '@/components/WindowControls.vue';
 const { loadSavedConfig, getWindowPosition, windowDrag, refreshCurrentUser } = useBridge();
 const activeTab = ref('account');
 const isInitializing = ref(true);
+
+// 响应式布局
+const windowWidth = ref(window.innerWidth);
+const isCompact = computed(() => windowWidth.value < 620);
+const isSidebarOpen = ref(false);
+const handleResize = () => { windowWidth.value = window.innerWidth; };
 
 const userInfo = reactive({ isLoggedIn: false, uname: '', face: '', level: 0, uid: '', money: 0, bcoin: 0, following: 0, follower: 0, dynamic_count: 0, current_exp: 0, next_exp: 0 });
 const globalForm = reactive({ roomId: '', cookie: '', csrf: '', title: '', area: '', subArea: '' });
@@ -94,6 +100,8 @@ const handlePointerUp = (event) => {
 // --- 结束 ---
 
 onMounted(async () => {
+  window.addEventListener('resize', handleResize);
+
   try {
     const user = await loadSavedConfig();
     if (user && user.uid) {
@@ -135,6 +143,7 @@ onMounted(async () => {
 });
 
 onUnmounted(() => {
+  window.removeEventListener('resize', handleResize);
   window.onTrayLiveStarted = null;
   window.onTrayNeedFaceVerify = null;
   window.onTrayLiveStopped = null;
@@ -163,9 +172,15 @@ const onSwitchAccount = (data) => {
 const onLogout = () => { Object.assign(userInfo, { isLoggedIn: false }); globalForm.roomId = ''; globalForm.cookie = ''; globalForm.csrf = ''; activeTab.value = 'account'; showModal('提示', '已退出登录', 'info'); };
 const updateForm = (key, value) => { globalForm[key] = value; };
 
+const handleTabChange = (tab) => {
+  activeTab.value = tab;
+  if (isCompact.value) isSidebarOpen.value = false;
+};
+
 const handleSidebarAccountClick = () => {
   showAccountManager.value = true;
   tryRefreshUserInfo();
+  if (isCompact.value) isSidebarOpen.value = false;
 };
 </script>
 
@@ -179,17 +194,27 @@ const handleSidebarAccountClick = () => {
       @pointermove="handlePointerMove"
       @pointerup="handlePointerUp"
     >
-      <div class="app-title">B站直播工具</div>
+      <div class="drag-bar-left">
+        <button v-if="isCompact" class="menu-btn" @click.stop="isSidebarOpen = !isSidebarOpen">☰</button>
+        <div class="app-title">B站直播工具</div>
+      </div>
       <WindowControls />
     </div>
 
     <div class="app-layout">
-      <Sidebar
-        :active-tab="activeTab"
-        :user="userInfo"
-        @change="t => activeTab = t"
-        @show-account-manager="handleSidebarAccountClick"
-      />
+      <!-- 侧边栏遮罩层（紧凑模式） -->
+      <Transition name="fade-backdrop">
+        <div v-if="isCompact && isSidebarOpen" class="sidebar-backdrop" @click="isSidebarOpen = false"></div>
+      </Transition>
+
+      <div class="sidebar-wrapper" :class="{ 'is-open': isSidebarOpen }">
+        <Sidebar
+          :active-tab="activeTab"
+          :user="userInfo"
+          @change="handleTabChange"
+          @show-account-manager="handleSidebarAccountClick"
+        />
+      </div>
       <main class="content">
         <KeepAlive>
           <component
@@ -249,14 +274,57 @@ const handleSidebarAccountClick = () => {
   touch-action: none; /* 禁用触摸滚动等默认行为 */
 }
 
+.drag-bar-left {
+  display: flex; align-items: center; gap: 4px;
+  pointer-events: none; /* 子元素各自控制 */
+}
+
+.menu-btn {
+  pointer-events: all;
+  background: none; border: none; cursor: pointer;
+  font-size: 16px; line-height: 1;
+  padding: 4px 8px; margin-left: 4px;
+  border-radius: 6px; color: var(--text-sub);
+  transition: background 0.15s;
+}
+.menu-btn:hover { background: rgba(0,0,0,0.08); }
+
 .app-title {
-  font-size: 12px; margin-left: 12px; color: #666; font-weight: 500;
+  font-size: 12px; margin-left: 8px; color: #666; font-weight: 500;
   pointer-events: none;
 }
 
 /* 主布局 */
-.app-layout { display: flex; flex: 1; overflow: hidden; }
+.app-layout { display: flex; flex: 1; overflow: hidden; position: relative; }
 .content { flex: 1; padding: 40px; overflow-y: auto; background: var(--bg-color); }
+
+/* 侧边栏容器 */
+.sidebar-wrapper { flex-shrink: 0; }
+
+/* 紧凑模式遮罩 */
+.sidebar-backdrop {
+  position: absolute; inset: 0;
+  background: rgba(0,0,0,0.3);
+  z-index: 199;
+}
+
+/* 遮罩淡入淡出动画 */
+.fade-backdrop-enter-active, .fade-backdrop-leave-active { transition: opacity 0.2s; }
+.fade-backdrop-enter-from, .fade-backdrop-leave-to { opacity: 0; }
+
+/* 响应式：紧凑模式 */
+@media (max-width: 620px) {
+  .sidebar-wrapper {
+    position: absolute;
+    left: 0; top: 0; height: 100%;
+    z-index: 200;
+    transform: translateX(-100%);
+    transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+    box-shadow: 4px 0 20px rgba(0,0,0,0.12);
+  }
+  .sidebar-wrapper.is-open { transform: translateX(0); }
+  .content:has(.danmu-panel) { padding: 0; }
+}
 
 /* 原有样式保持不变 */
 .loading-screen { height: 100vh; width: 100vw; display: flex; flex-direction: column; align-items: center; justify-content: center; background: var(--bg-color); color: var(--text-sub); }

--- a/frontend/src/api/bridge.js
+++ b/frontend/src/api/bridge.js
@@ -189,6 +189,14 @@ export const useBridge = () => {
       return res;
     },
 
+    // 弹幕面板窗口控制
+    async setWindowOpacity(opacityPercent) {
+      return await callPy('set_window_opacity', opacityPercent);
+    },
+    async setWindowTopmost(onTop) {
+      return await callPy('set_window_topmost', onTop);
+    },
+
     // App 配置
     async getAppConfig() {
       const res = await callPy('get_app_config');

--- a/frontend/src/components/DanmuPanel.vue
+++ b/frontend/src/components/DanmuPanel.vue
@@ -1,13 +1,38 @@
 <script setup>
-import { ref, onMounted, onUnmounted, nextTick } from 'vue';
+import { ref, watch, onMounted, onUnmounted, nextTick } from 'vue';
 import { useBridge } from '@/api/bridge';
 
-const { startDanmuMonitor, stopDanmuMonitor, sendDanmu } = useBridge();
+const { startDanmuMonitor, stopDanmuMonitor, sendDanmu, setWindowOpacity, setWindowTopmost } = useBridge();
 const messages = ref([]);
 const messageListRef = ref(null);
 const isAutoScroll = ref(true);
 const inputMsg = ref('');
 const sending = ref(false);
+
+// 置顶状态
+const isTopmost = ref(false);
+const toggleTopmost = async () => {
+  isTopmost.value = !isTopmost.value;
+  const res = await setWindowTopmost(isTopmost.value);
+  if (res && res.code !== 0) {
+    console.error('置顶失败:', res.msg);
+    isTopmost.value = !isTopmost.value; // 回滚
+  }
+};
+
+// 透明度 (100 = 完全不透明)
+const opacity = ref(100);
+let opacityTimer = null;
+watch(opacity, (val) => {
+  // 拖动时节流，避免频繁调用
+  clearTimeout(opacityTimer);
+  opacityTimer = setTimeout(async () => {
+    const res = await setWindowOpacity(val);
+    if (res && res.code !== 0) {
+      console.error('透明度设置失败:', res.msg);
+    }
+  }, 80);
+});
 
 const addMessage = (data) => {
   messages.value.push(data);
@@ -89,8 +114,21 @@ onUnmounted(() => {
     <div class="danmu-header">
       <h3>弹幕监控</h3>
       <div class="controls">
-        <label>
+        <label class="ctrl-label">
           <input type="checkbox" v-model="isAutoScroll"> 自动滚动
+        </label>
+        <button
+          class="ctrl-btn"
+          :class="{ active: isTopmost }"
+          @click="toggleTopmost"
+          :title="isTopmost ? '取消置顶' : '置顶显示'"
+        >
+          📌 {{ isTopmost ? '已置顶' : '置顶' }}
+        </button>
+        <label class="ctrl-label opacity-label" title="调节窗口不透明度">
+          <span>透明度</span>
+          <input type="range" min="70" max="100" v-model.number="opacity" class="opacity-slider" />
+          <span class="opacity-val">{{ opacity }}%</span>
         </label>
       </div>
     </div>
@@ -157,22 +195,22 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   height: 100%;
-
-  /* [核心修改] 宽度 80% 并居中 */
-  width: 80%;
+  width: 100%;
+  max-width: 680px;
   margin: 0 auto;
-
   background: #f2f2f2; /* QQ 经典的浅灰底色 */
-  border-radius: 16px; /* 圆润边框 */
+  border-radius: 16px;
   overflow: hidden;
   font-family: "PingFang SC", "Microsoft YaHei", "WenQuanYi Micro Hei", sans-serif;
   box-shadow: 0 4px 12px rgba(0,0,0,0.03);
+  box-sizing: border-box;
 }
 
 .danmu-header {
   padding: 12px 18px;
   border-bottom: 1px solid rgba(0,0,0,0.06);
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
   align-items: center;
   background: #f9f9f9;
@@ -186,14 +224,49 @@ onUnmounted(() => {
 }
 
 .controls {
-  font-size: 12px;
-  color: #666;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
   user-select: none;
 }
-.controls input {
-  vertical-align: middle;
-  margin-top: -2px;
+
+.ctrl-label {
+  font-size: 12px;
+  color: #666;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  white-space: nowrap;
 }
+.ctrl-label input[type="checkbox"] {
+  vertical-align: middle;
+  margin-top: -1px;
+}
+
+.ctrl-btn {
+  font-size: 11px;
+  padding: 3px 10px;
+  border: 1px solid #d1d5db;
+  border-radius: 12px;
+  background: white;
+  color: #555;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.15s;
+  font-family: inherit;
+}
+.ctrl-btn:hover { background: #f3f4f6; border-color: #9ca3af; }
+.ctrl-btn.active { background: #dbeafe; border-color: #60a5fa; color: #2563eb; font-weight: 600; }
+
+.opacity-label { gap: 6px; }
+.opacity-slider {
+  width: 70px;
+  height: 4px;
+  cursor: pointer;
+  accent-color: var(--primary-color);
+}
+.opacity-val { min-width: 28px; color: #888; }
 
 .message-list {
   flex: 1;
@@ -361,6 +434,28 @@ onUnmounted(() => {
   background: #e0e0e0;
   color: #aaa;
   cursor: not-allowed;
+}
+
+/* === 紧凑模式（≤620px）=== */
+@media (max-width: 620px) {
+  .danmu-panel {
+    max-width: 100%;
+    border-radius: 0;
+    box-shadow: none;
+    background: var(--bg-color, #f2f2f2);
+  }
+
+  .danmu-header {
+    padding: 8px 10px;
+  }
+
+  .message-list {
+    padding: 8px 10px;
+  }
+
+  .send-area {
+    padding: 8px 10px;
+  }
 }
 
 /* === 动画效果 === */

--- a/main.py
+++ b/main.py
@@ -154,7 +154,9 @@ if __name__ == '__main__':
                     
                     # 1. 去除 WS_THICKFRAME (0x00040000) 以消除顶部白条
                     #    之前的尝试中添加了这个样式导致了白条
-                    style &= ~0x00040000
+                    # style &= ~0x00040000
+                    # 但我们现在需要使窗口可以 resize
+                    style |= 0x00040000  # WS_THICKFRAME
                     
                     # 2. 添加 WS_MINIMIZEBOX (0x00020000) 以支持任务栏点击最小化
                     style |= 0x00020000 
@@ -164,6 +166,9 @@ if __name__ == '__main__':
                     # 刷新窗口状态
                     # SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED
                     user32.SetWindowPos(hwnd, 0, 0, 0, 0, 0, 0x0002 | 0x0001 | 0x0004 | 0x0020)
+
+                    # 注入 HWND 到 window_service，供透明度/置顶 API 使用
+                    api.window_service.set_hwnd(hwnd)
             except Exception as e:
                 logger.error(f"Failed to set window style: {e}")
 


### PR DESCRIPTION
部分代码使用Copilot编写，已经过人工确认。
主要修改是当窗口较小时启用侧边栏，单击打开收起，主区域可以显示更多内容。在DanmuPanel时，若处于compact mode则去掉边距，可以显示更多弹幕，支持了在windows下的窗口半透明和窗口总在最前，可用于直播时互动。

已知问题是在`main.py` 157行附近修改为了`style |= 0x00040000  # WS_THICKFRAME`导致窗口出现黑边且无法resize，没能搞定同时支持resize和无黑边，还烦请维护者再折腾折腾。