### PR TITLE
修复 macOS 工作流

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,14 +168,14 @@ jobs:
             --hidden-import brotli\
             --collect-all cffi \
             --collect-all brotli
-
-        else
+        elif [ "${{ matrix.os }}" == "macos-latest" ]; then
             pyinstaller main.py \
               --name BiliLiveTool \
               --onefile \
               --add-data "frontend/dist:frontend/dist" \
               --add-data "bilibili.ico:." \
               --icon "$ICON_NAME" \
+              --hidden-import _cffi_backend
               $EXTRA_ARGS \
               ${{ matrix.pyinstaller_options }}
         fi

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@
 
    - **macOS**:
      ```bash
-     pyinstaller main.py --name BiliLiveTool --onefile --add-data "frontend/dist:frontend/dist" --icon "bilibili.icns" --windowed
+     pyinstaller main.py --name BiliLiveTool --onefile --add-data "frontend/dist:frontend/dist" --icon "bilibili.icns" --hidden-import _cffi_backend --windowed
      ```
 
    - **Linux**:

--- a/main.py
+++ b/main.py
@@ -1,15 +1,22 @@
 import os
 import sys
 
-# [修复] 强制 Linux 下使用 x11 后端 (XWayland)
-# 1. GDK_BACKEND=x11: 修复 Wayland 下 GTK 托盘初始化崩溃 "Can't create GtkStyleContext without display"
-# 2. QT_QPA_PLATFORM=xcb: 强制 Qt 使用 X11 后端，确保窗口拖动 (window.move) 和位置控制在 Wayland 下正常工作
-if sys.platform != 'win32':
+# [修复] 根据平台设置不同的环境变量
+if sys.platform == 'linux':
+    # Linux: 强制使用 x11 后端 (XWayland)
+    # 1. GDK_BACKEND=x11: 修复 Wayland 下 GTK 托盘初始化崩溃 "Can't create GtkStyleContext without display"
+    # 2. QT_QPA_PLATFORM=xcb: 强制 Qt 使用 X11 后端，确保窗口拖动 (window.move) 和位置控制在 Wayland 下正常工作
     os.environ["GDK_BACKEND"] = "x11"
     os.environ["QT_QPA_PLATFORM"] = "xcb"
     # [Fix] 强制使用 Fusion 风格，防止 Qt 尝试加载 GTK 主题 (QGtkStyle) 导致崩溃
     os.environ["QT_STYLE_OVERRIDE"] = "Fusion"
     # [Fix] 禁用平台主题插件 (如 qt5ct, gtk2)，防止它们加载 GTK
+    if "QT_QPA_PLATFORMTHEME" in os.environ:
+        del os.environ["QT_QPA_PLATFORMTHEME"]
+elif sys.platform == 'darwin':
+    # macOS: 使用原生 cocoa 后端
+    os.environ["QT_QPA_PLATFORM"] = "cocoa"
+    # 禁用 GTK 后端
     if "QT_QPA_PLATFORMTHEME" in os.environ:
         del os.environ["QT_QPA_PLATFORMTHEME"]
 


### PR DESCRIPTION
修复对 macOS 的构建，指定 `cocoa` 为后端并增加 `hidden-import` 参数，以允许程序成功启动并正常使用。

测试环境：macOS M2 Tahoe 26.4

修复以下报错：
```
./dist/BiliLiveTool
Traceback (most recent call last):
  File "main.py", line 19, in <module>
    from backend.api_service import ApiService
  File "pyimod02_importers.py", line 457, in exec_module
  File "backend/api_service.py", line 11, in <module>
    from backend.services.danmu_service import DanmuService
  File "pyimod02_importers.py", line 457, in exec_module
  File "backend/services/danmu_service.py", line 8, in <module>
    import brotli
  File "pyimod02_importers.py", line 457, in exec_module
  File "brotli/__init__.py", line 3, in <module>
  File "pyimod02_importers.py", line 457, in exec_module
  File "brotli/brotli.py", line 5, in <module>
ModuleNotFoundError: No module named '_cffi_backend'
[PYI-82070:ERROR] Failed to execute script 'main' due to unhandled exception: No module named '_cffi_backend'
[PYI-82070:ERROR] Traceback:
Traceback (most recent call last):
  File "main.py", line 19, in <module>
    from backend.api_service import ApiService
  File "pyimod02_importers.py", line 457, in exec_module
  File "backend/api_service.py", line 11, in <module>
    from backend.services.danmu_service import DanmuService
  File "pyimod02_importers.py", line 457, in exec_module
  File "backend/services/danmu_service.py", line 8, in <module>
    import brotli
  File "pyimod02_importers.py", line 457, in exec_module
  File "brotli/__init__.py", line 3, in <module>
  File "pyimod02_importers.py", line 457, in exec_module
  File "brotli/brotli.py", line 5, in <module>
ModuleNotFoundError: No module named '_cffi_backend'
```

```
./dist/BiliLiveTool
2026-03-29 02:19:02,214 - Main            - INFO     - Log file path: /mypath/bilibili_live_stream_code/dist/logs/app.log
2026-03-29 02:19:02,215 - UserService     - INFO     - Init user: MyID
2026-03-29 02:19:02,215 - asyncio         - DEBUG    - Using selector: KqueueSelector
qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: cocoa, minimal, offscreen, webgl.

zsh: abort      ./dist/BiliLiveTool
```
