### PR TITLE
docs: README 补充 Tauri 重构版本与 macOS 适配说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@
 
 1. 支持推流码类型：RTMP和SRT；
 2. 因为本人穷，用不起mac，mac用户可以自行进行测试，如果调试到可以正常运行，欢迎提交pr；
+3. 社区已有基于本项目的 Tauri 重构版本，技术栈从 Python + PyInstaller 迁移至 **Tauri 2.x (Rust) + React 18 + TypeScript**，并补全了 macOS 端的适配（含托盘、窗口退出、深色模式等）。有需要的同学可以移步 [Zeppelinpp/bilibili-streamer](https://github.com/Zeppelinpp/bilibili-streamer) 查看。
 
 ### ⭐ Star 历史
 


### PR DESCRIPTION
## 背景

本项目目前有社区同学基于原仓库进行了完整重构，技术栈从 Python + PyInstaller 迁移到了 **Tauri 2.x (Rust) + React 18 + TypeScript**，并补全了之前缺乏测试环境的 macOS 端适配（托盘行为、窗口退出、深色模式等）。

不少找 macOS 支持的同学可能会在 issue 里反复询问，因此在 README 里加一条简要说明，方便后来者直接跳转。
或者可以作为一个分支并入仓库也可以

## 改动内容

- 在 README「其他」小节新增第 3 点，简要介绍重构版本的技术栈迁移与 macOS 适配情况；
- 附上重构仓库链接 [Zeppelinpp/bilibili-streamer](https://github.com/Zeppelinpp/bilibili-streamer)。

如有表述不妥的地方，欢迎直接修改或关闭。