### PR TITLE
fix: 修复Arch上弹幕服务器TLS证书验证失败的问题

### DIFF
--- a/backend/services/danmu_service.py
+++ b/backend/services/danmu_service.py
@@ -4,9 +4,11 @@ import logging
 import struct
 import zlib
 import base64
+import ssl
 
 import brotli
 import aiohttp
+import certifi
 from backend import get_wbi
 from backend import util
 from backend import dm_pb2
@@ -187,8 +189,10 @@ class DanmuService:
         ws_url = f"wss://{host_list[0]['host']}:{host_list[0]['wss_port']}/sub"
         
         try:
+            # PyInstaller 打包后默认 CA 路径可能来自构建机，使用 certifi 保证 WSS 校验一致。
+            ssl_context = ssl.create_default_context(cafile=certifi.where())
             self.session = aiohttp.ClientSession()
-            self.ws = await self.session.ws_connect(ws_url, headers=self.api.headers)
+            self.ws = await self.session.ws_connect(ws_url, headers=self.api.headers, ssl=ssl_context)
             
             # 发送认证包
             auth_data = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "protobuf",
     "brotlipy",
     "aiohttp",
+    "certifi",
     "Pillow",
     "qtpy>=2.4.0",
     "PyQt5>=5.15.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ pyinstaller
 protobuf
 brotlipy
 aiohttp
+certifi
 Pillow
 qtpy>=2.4.0
 PyQt5>=5.15.0


### PR DESCRIPTION
## 背景

Linux 版本通过 PyInstaller 打包后，内置 Python/OpenSSL 的默认 CA 路径为`/usr/lib/ssl/certs` ，这与用户运行环境的系统 CA 路径不一定一致。例如 Arch Linux 下的默认路径为 `/etc/ssl/certs`，由此导致弹幕服务器 WebSocket 连接失败，log中出现：

<img width="920" height="99" alt="image" src="https://github.com/user-attachments/assets/945ecd7d-831e-41b6-b9f0-1d0dabb340c2" />

该问题在 v2.3.16 版本，系统 Omarchy 3.8.2 - Linux 7.0.10-arch1-1 上可以稳定复现。

## 修改内容

- 在弹幕 WSS 连接时显式使用 certifi 提供的 CA bundle 创建 SSL context
- 增加 certifi 依赖

## 验证

- 使用 uv 创建本地虚拟环境并安装依赖
- 前端执行 npm ci && npm run build 成功
- 使用 PyInstaller 完成 Linux 版本构建
- 构建版本无该问题，可正常连接弹幕服务器



