### PR TITLE
fix: 兼容 Linux Wayland 启动环境

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,16 +1,32 @@
 import os
 import sys
 
+
+def _append_env_flags(name, *flags):
+    current_flags = os.environ.get(name, "").split()
+    for flag in flags:
+        if flag not in current_flags:
+            current_flags.append(flag)
+    os.environ[name] = " ".join(current_flags)
+
+
 # [修复] 根据平台设置不同的环境变量
 if sys.platform == 'linux':
-    os.environ["GDK_BACKEND"] = "x11"
-    os.environ["QT_QPA_PLATFORM"] = "xcb"
-    os.environ["QT_STYLE_OVERRIDE"] = "Fusion"
-    os.environ["XDG_SESSION_TYPE"] = "cxb"
+    is_wayland = (
+        os.environ.get("XDG_SESSION_TYPE", "").lower() == "wayland"
+        or bool(os.environ.get("WAYLAND_DISPLAY"))
+    )
+    if is_wayland:
+        os.environ.setdefault("GDK_BACKEND", "wayland,x11")
+        os.environ.setdefault("QT_QPA_PLATFORM", "wayland;xcb")
+    else:
+        os.environ.setdefault("GDK_BACKEND", "x11")
+        os.environ.setdefault("QT_QPA_PLATFORM", "xcb")
+    os.environ.setdefault("QT_STYLE_OVERRIDE", "Fusion")
     if "QT_QPA_PLATFORMTHEME" in os.environ:
         os.environ["QT_QPA_PLATFORMTHEME"] = ""
-    os.environ["QT_XCB_GL_INTEGRATION"] = "none"
-    os.environ["QTWEBENGINE_CHROMIUM_FLAGS"] = "--disable-gpu --no-sandbox --enable-features=UseOzonePlatform --ozone-platform=x11"
+    # QtWebEngine 5.15 可能不支持显式 ozone 参数，这里交给 Qt 自行选择 Wayland/X11。
+    _append_env_flags("QTWEBENGINE_CHROMIUM_FLAGS", "--disable-gpu", "--no-sandbox")
 elif sys.platform == 'win32':
     os.environ["QT_OPENGL"] = "software"
     os.environ["QTWEBENGINE_CHROMIUM_FLAGS"] = "--disable-gpu --disable-software-rasterizer"


### PR DESCRIPTION
## 背景

当前 Linux 启动时会强制设置 X11/XCB 相关环境变量，并传入显式 ozone platform：

```
QT_QPA_PLATFORM=xcb
XDG_SESSION_TYPE=cxb
QT_XCB_GL_INTEGRATION=none
QTWEBENGINE_CHROMIUM_FLAGS=... --ozone-platform=x11
```

这导致在 hyprland（wayland）环境下启动失败，报错：

```
QXcbIntegration: Cannot create platform OpenGL context, neither GLX nor EGL are enabled
[1115048:1115048:0625/030708.191070:FATAL:platform_selection.cc(48)] Invalid ozone platform: x11
```

该问题在release v2.3.16 中未出现，但出现在基于 012094c0e330cbf99a745fa6881fbabacc1ffc3f 的构建版本中。作为 #61 的补充，将其拆分到这个独立的PR中

## 修改内容

- 根据当前会话判断是否处于 Wayland 环境。
- Wayland 环境下默认使用 wayland;xcb，允许 Qt 自动 fallback。
- 不再覆盖用户已有的相关环境变量。
- 移除固定的 ozone platform 参数，避免 QtWebEngine 5.15 不兼容。
- 移除错误的 XDG_SESSION_TYPE=cxb 覆盖。

## 验证

本地源码运行成功
本地 PyInstaller 构建成功
打包后的 BiliLiveTool 在 `Hyprland 0.55.2 (Wayland)` 下启动成功，无报错
<img width="2560" height="1440" alt="screenshot-2026-06-25_03-41-24" src="https://github.com/user-attachments/assets/1daac135-803b-4fc9-bae3-bf79ab20922d" />

验证环境：

Omarchy 3.8.2 - Linux 7.0.10-arch1-1
Hyprland 0.55.2 (Wayland)
Intel Iris Xe Graphics